### PR TITLE
Bug/set bot online

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Use `/support` command to create a support ticket.
 2. Navigate to the "Settings" section.
 3. Under "Webhook Configuration", enter the following URL:
   ```
-  http://<YOUR_PUBLIC_URL>:3000/unthread/webhook
+  http://<YOUR_PUBLIC_URL>:3000/webhook/unthread
   ```
     Replace `<YOUR_PUBLIC_URL>` with the public URL provided by VS Code.
 4. Save the settings.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@keyv/redis": "^4.3.1",
+    "cacheable": "^1.8.9",
     "crypto": "^1.0.1",
     "discord.js": "^14.18.0",
     "dotenv": "^16.4.7",

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -6,6 +6,7 @@ module.exports = {
     once: true,
     execute(bot) {
         bot.user?.setPresence({
+            status: 'online', // Explicitly set status to online
             activities: [{
                 name: `support tickets`,
                 type: ActivityType.Listening

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -5,8 +5,10 @@ module.exports = {
     name: Events.ClientReady,
     once: true,
     execute(bot) {
+        // Explicitly set the bot's status to 'online' to ensure it appears online to users
+        // This is important as sometimes Discord bots may default to 'idle' or not show proper status
         bot.user?.setPresence({
-            status: 'online', // Explicitly set status to online
+            status: 'online',
             activities: [{
                 name: `support tickets`,
                 type: ActivityType.Listening

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const path = require("node:path");
 const { Client, Collection, GatewayIntentBits, Partials } = require("discord.js");
 const express = require('express');
 const app = express();
-const port = process.env.PORT || 5000;
+const port = process.env.PORT || 3000;
 const { handleWebhookEvent } = require('./services/unthread');
 const { webhookHandler } = require('./services/webhook');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,14 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cacheable@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/cacheable/-/cacheable-1.8.9.tgz#f5498999567ae1015761d805bd8bbecd8393fbd4"
+  integrity sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==
+  dependencies:
+    hookified "^1.7.1"
+    keyv "^5.3.1"
+
 call-bind-apply-helpers@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -551,6 +559,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hookified@^1.7.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/hookified/-/hookified-1.8.1.tgz#74a8c97d36e5f8004d230ee2156a607cc84c358c"
+  integrity sha512-GrO2l93P8xCWBSTBX9l2BxI78VU/MAAYag+pG8curS3aBGy0++ZlxrQ7PdUOUVMbn5BwkGb6+eRrnf43ipnFEA==
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and configuration of the project. The most important changes include updates to the webhook URL in the `README.md`, the addition of a new dependency in `package.json`, setting the bot's status explicitly in `src/events/ready.js`, and changing the default port in `src/index.js`.

Configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R89): Updated the webhook URL to `http://<YOUR_PUBLIC_URL>:3000/webhook/unthread` to correct the path.
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L6-R6): Changed the default port from 5000 to 3000 to align with the expected configuration.

Dependency management:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27): Added the `cacheable` dependency to the project.

Bot functionality:

* [`src/events/ready.js`](diffhunk://#diff-d65036aa21047a6f6845b69b36a6ca6ed9cccc8ce287af4ef504ed7778764bc9R8-R11): Added code to explicitly set the bot's status to 'online' to ensure it appears online to users.