### PR TITLE
🐛 fix: Railway SIGTERM issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ FORUM_CHANNEL_IDS=channel_id_1,channel_id_2
 # ALL OTHER CONFIGURATION USES SENSIBLE DEFAULTS
 # =============================================================================
 # The following are handled automatically by src/config/defaults.ts:
-# - PORT: 3000
+# - PORT: 3001
 # - UNTHREAD_HTTP_TIMEOUT_MS: 10000
 # - WEBHOOK_POLL_INTERVAL: 1000
 # - UNTHREAD_DEFAULT_PRIORITY: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
   # cross-repository management and standardized tooling.
   server:
     build: .  # Build from local Dockerfile instead of pulling from Docker Hub
+    ports:
+      - "3001:3001"  # Discord bot health endpoint
     env_file:
       - .env  # Contains bot tokens, API keys, and database URLs (including NODE_ENV)
     depends_on:

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,11 +1,7 @@
 /**
  * Default Configuration System
  *
- * Provides production-safe defaults for the Discord 	export function getAllConfig() {
-	return {
-		NODE_ENV: getConfig('NODE_ENV', DEFAULT_CONFIG.NODE_ENV),
-		PORT: getConfig('PORT', DEFAULT_CONFIG.PORT),
-		UNTHREAD_HTTP_TIMEOUT_MS: getConfig('UNTHREAD_HTTP_TIMEOUT_MS', DEFAULT_CONFIG.UNTHREAD_HTTP_TIMEOUT_MS),onfiguration.
+ * Provides production-safe defaults for the Discord bot configuration.
  * This follows Node.js best practices by using NODE_ENV for environment detection
  * and hardcoding sensible defaults that don't require user configuration.
  *

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,7 +1,11 @@
 /**
  * Default Configuration System
  *
- * Provides production-safe defaults for the Discord bot configuration.
+ * Provides production-safe defaults for the Discord 	export function getAllConfig() {
+	return {
+		NODE_ENV: getConfig('NODE_ENV', DEFAULT_CONFIG.NODE_ENV),
+		PORT: getConfig('PORT', DEFAULT_CONFIG.PORT),
+		UNTHREAD_HTTP_TIMEOUT_MS: getConfig('UNTHREAD_HTTP_TIMEOUT_MS', DEFAULT_CONFIG.UNTHREAD_HTTP_TIMEOUT_MS),onfiguration.
  * This follows Node.js best practices by using NODE_ENV for environment detection
  * and hardcoding sensible defaults that don't require user configuration.
  *
@@ -40,7 +44,7 @@ import { LogEngine } from '@wgtechlabs/log-engine';
 export const DEFAULT_CONFIG = {
 	// Production-safe defaults
 	NODE_ENV: 'production',
-	PORT: 3000,
+	PORT: 3001,
 
 	// Timeouts & Performance (hardcoded - no env needed)
 	UNTHREAD_HTTP_TIMEOUT_MS: 10000,

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -14,7 +14,7 @@
  */
 
 import { LogEngine, LogMode } from '@wgtechlabs/log-engine';
-import { isDevelopment } from './defaults.js';
+import { isDevelopment } from './defaults';
 
 // Set the log mode based on NODE_ENV environment variable
 // In development mode (or undefined NODE_ENV), show all logs; otherwise show info and above

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -61,7 +61,7 @@ export interface BotConfig {
 	WEBHOOK_REDIS_URL: string;
 	/** Comma-separated list of forum channel IDs for auto-ticket creation (optional) */
 	FORUM_CHANNEL_IDS?: string;
-	/** Port for webhook server (optional, defaults to 3000) */
+	/** Port for Discord bot health endpoint (optional, defaults to 3001) */
 	PORT?: string;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a lightweight health check server with /health and /ping endpoints, reporting overall status (healthy/degraded) and shutting down gracefully with the app.

- Chores
  - Updated default port to 3001 and exposed host port 3001 in container setup to surface the health endpoint consistently.

- Documentation
  - Clarified that the PORT setting refers to the Discord bot health endpoint with a default of 3001.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->