### PR TITLE
🔧 update: align attachment support with webhook server and telegram bot

### DIFF
--- a/src/__tests__/utils/attachmentHandler.test.ts
+++ b/src/__tests__/utils/attachmentHandler.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('discord.js', () => {
+	class MockAttachmentBuilder {
+		attachment: Buffer;
+		name?: string;
+		description?: string;
+
+		constructor(buffer: Buffer, options?: { name?: string; description?: string }) {
+			this.attachment = buffer;
+			this.name = options?.name;
+			this.description = options?.description;
+		}
+	}
+
+	class MockEmbedBuilder {
+		setColor = vi.fn().mockReturnThis();
+		setTitle = vi.fn().mockReturnThis();
+		setDescription = vi.fn().mockReturnThis();
+		setFooter = vi.fn().mockReturnThis();
+		setTimestamp = vi.fn().mockReturnThis();
+	}
+
+	return {
+		AttachmentBuilder: MockAttachmentBuilder,
+		Collection: Map,
+		EmbedBuilder: MockEmbedBuilder,
+	};
+});
+
+import { AttachmentHandler } from '@utils/attachmentHandler';
+
+function createFetchResponse(body: Buffer, status = 200) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+		arrayBuffer: vi.fn().mockResolvedValue(
+			body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+		),
+	};
+}
+
+function createDiscordThread() {
+	return {
+		id: 'discord-thread-1',
+		send: vi.fn().mockResolvedValue({ id: 'discord-message-1' }),
+	};
+}
+
+describe('AttachmentHandler Unthread downloads', () => {
+	beforeEach(() => {
+		(global.fetch as any).mockReset();
+	});
+
+	it('downloads webhook files through the conversation-scoped fallback when no direct URL is present', async () => {
+		const body = Buffer.from([1, 2, 3, 4]);
+		(global.fetch as any).mockResolvedValueOnce(createFetchResponse(body));
+		const discordThread = createDiscordThread();
+		const attachmentHandler = new AttachmentHandler();
+
+		const result = await attachmentHandler.downloadUnthreadFilesToDiscord(
+			discordThread as any,
+			[
+				{
+					id: 'file_123',
+					name: 'dashboard-image.png',
+					size: body.length,
+					mimetype: 'image/png',
+				},
+			],
+			undefined,
+			'conversation 123',
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.processedCount).toBe(1);
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://api.unthread.io/api/conversations/conversation%20123/files/file_123/full',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'X-API-KEY': 'test_unthread_api_key',
+					'User-Agent': 'unthread-discord-bot',
+				}),
+			}),
+		);
+		expect(discordThread.send).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores non-Unthread direct URLs and falls back to conversation file downloads', async () => {
+		const body = Buffer.from([5, 6, 7]);
+		(global.fetch as any).mockResolvedValueOnce(createFetchResponse(body));
+		const discordThread = createDiscordThread();
+		const attachmentHandler = new AttachmentHandler();
+
+		const result = await attachmentHandler.downloadUnthreadFilesToDiscord(
+			discordThread as any,
+			[
+				{
+					id: 'file_456',
+					name: 'unsafe-url-image.png',
+					size: body.length,
+					filetype: 'png',
+					urlPrivateDownload: 'https://example.invalid/file.png',
+				},
+			],
+			undefined,
+			'conv-456',
+		);
+
+		expect(result.success).toBe(true);
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://api.unthread.io/api/conversations/conv-456/files/file_456/full',
+			expect.objectContaining({ method: 'GET' }),
+		);
+		expect(discordThread.send).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses direct Unthread API URLs when provided by the webhook payload', async () => {
+		const body = Buffer.from([8, 9]);
+		(global.fetch as any).mockResolvedValueOnce(createFetchResponse(body));
+		const discordThread = createDiscordThread();
+		const attachmentHandler = new AttachmentHandler();
+
+		const result = await attachmentHandler.downloadUnthreadFilesToDiscord(
+			discordThread as any,
+			[
+				{
+					id: 'file_789',
+					name: 'direct-url-image.png',
+					size: body.length,
+					mimetype: 'image/png',
+					urlPrivateDownload: 'https://api.unthread.io/api/files/file_789/full',
+				},
+			],
+			undefined,
+			'conv-789',
+		);
+
+		expect(result.success).toBe(true);
+		expect(global.fetch).toHaveBeenCalledWith(
+			'https://api.unthread.io/api/files/file_789/full',
+			expect.objectContaining({ method: 'GET' }),
+		);
+		expect(discordThread.send).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/services/attachmentDetection.ts
+++ b/src/services/attachmentDetection.ts
@@ -17,7 +17,7 @@
 import { Collection, Attachment } from 'discord.js';
 import { DISCORD_ATTACHMENT_CONFIG, isSupportedImageType, normalizeContentType } from '../config/attachmentConfig';
 import { AttachmentValidationResult } from '../types/attachments';
-import { EnhancedWebhookEvent } from '../types/unthread';
+import { EnhancedWebhookEvent, WebhookAttachments, WebhookFileData } from '../types/unthread';
 import { LogEngine } from '../config/logger';
 
 /**
@@ -68,13 +68,89 @@ export class AttachmentDetectionService {
 			   event.targetPlatform === 'discord';
 	}
 
+	private static getMetadataAttachmentRecords(event: EnhancedWebhookEvent): Array<Record<string, unknown>> {
+		const metadata = event.data.metadata as {
+			event_payload?: {
+				attachments?: Array<Record<string, unknown>>;
+			};
+		} | undefined;
+
+		return Array.isArray(metadata?.event_payload?.attachments)
+			? metadata.event_payload.attachments
+			: [];
+	}
+
+	/**
+	 * Returns a normalized files list for processing.
+	 * Falls back to metadata.event_payload.attachments when event.data.files is unavailable.
+	 */
+	static getProcessableFiles(event: EnhancedWebhookEvent): WebhookFileData[] {
+		if (!this.shouldProcessEvent(event)) {
+			return [];
+		}
+
+		if (Array.isArray(event.data.files) && event.data.files.length > 0) {
+			return event.data.files;
+		}
+
+		const metadataAttachments = this.getMetadataAttachmentRecords(event);
+		if (metadataAttachments.length === 0) {
+			return [];
+		}
+
+		return metadataAttachments
+			.filter(record => typeof record.id === 'string' && record.id.trim().length > 0)
+			.map(record => {
+				const rawType = typeof record.type === 'string' ? record.type : '';
+				const normalizedType = rawType ? this.normalizeType(rawType) : 'application/octet-stream';
+				const rawSize = record.size;
+				const parsedSize = typeof rawSize === 'number'
+					? rawSize
+					: Number.parseInt(String(rawSize ?? '0'), 10);
+
+				return {
+					id: String(record.id),
+					name: typeof record.name === 'string' && record.name.trim().length > 0
+						? record.name
+						: String(record.id),
+					size: Number.isFinite(parsedSize) && parsedSize > 0 ? parsedSize : 0,
+					mimetype: normalizedType,
+				} as WebhookFileData;
+			});
+	}
+
+	/**
+	 * Returns resolved attachment metadata, with fallback generation from processable files.
+	 */
+	static getResolvedAttachments(event: EnhancedWebhookEvent): WebhookAttachments | null {
+		if (!this.shouldProcessEvent(event)) {
+			return null;
+		}
+
+		if (event.attachments?.hasFiles === true) {
+			return event.attachments;
+		}
+
+		const files = this.getProcessableFiles(event);
+		if (files.length === 0) {
+			return null;
+		}
+
+		return {
+			hasFiles: true,
+			fileCount: files.length,
+			totalSize: files.reduce((sum, file) => sum + (file.size || 0), 0),
+			types: Array.from(new Set(files.map(file => this.normalizeType(file.mimetype || 'application/octet-stream')))),
+			names: files.map(file => file.name || file.id || 'unnamed-file'),
+		};
+	}
+
 	/**
 	 * Primary attachment detection using webhook metadata
 	 * Replaces complex array checking and location detection
 	 */
 	static hasAttachments(event: EnhancedWebhookEvent): boolean {
-		return this.shouldProcessEvent(event) &&
-			   event.attachments?.hasFiles === true;
+		return this.getResolvedAttachments(event)?.hasFiles === true;
 	}
 
 	/**
@@ -125,7 +201,7 @@ export class AttachmentDetectionService {
 		if (!this.hasAttachments(event)) {
 			return true;
 		}
-		const files = event.data.files ?? [];
+		const files = this.getProcessableFiles(event);
 		if (files.length === 0) return true;
 		return files.every(f => f.size <= maxSizeBytes);
 	}
@@ -138,7 +214,7 @@ export class AttachmentDetectionService {
 		if (!this.hasAttachments(event)) {
 			return false;
 		}
-		const files = event.data.files ?? [];
+		const files = this.getProcessableFiles(event);
 		if (files.length === 0) return false;
 		return files.some(f => f.size > maxSizeBytes);
 	}
@@ -148,11 +224,7 @@ export class AttachmentDetectionService {
 	 * Ready-to-use summary without manual calculation
 	 */
 	static getAttachmentSummary(event: EnhancedWebhookEvent): string {
-		if (!this.hasAttachments(event)) {
-			return 'No attachments';
-		}
-
-		const attachments = event.attachments;
+		const attachments = this.getResolvedAttachments(event);
 		if (!attachments) {
 			return 'No attachments';
 		}
@@ -169,7 +241,7 @@ export class AttachmentDetectionService {
 	 * Instant count from metadata
 	 */
 	static getFileCount(event: EnhancedWebhookEvent): number {
-		return event.attachments?.fileCount || 0;
+		return this.getResolvedAttachments(event)?.fileCount || 0;
 	}
 
 	/**
@@ -177,7 +249,7 @@ export class AttachmentDetectionService {
 	 * Pre-calculated size from metadata
 	 */
 	static getTotalSize(event: EnhancedWebhookEvent): number {
-		return event.attachments?.totalSize || 0;
+		return this.getResolvedAttachments(event)?.totalSize || 0;
 	}
 
 	/**
@@ -185,7 +257,7 @@ export class AttachmentDetectionService {
 	 * Deduplicated types from metadata
 	 */
 	static getFileTypes(event: EnhancedWebhookEvent): string[] {
-		return event.attachments?.types || [];
+		return this.getResolvedAttachments(event)?.types || [];
 	}
 
 	/**
@@ -193,7 +265,7 @@ export class AttachmentDetectionService {
 	 * names[i] corresponds to data.files[i]
 	 */
 	static getFileNames(event: EnhancedWebhookEvent): string[] {
-		return event.attachments?.names || [];
+		return this.getResolvedAttachments(event)?.names || [];
 	}
 
 	/**
@@ -206,15 +278,15 @@ export class AttachmentDetectionService {
 		}
 
 		const metadata = event.attachments;
-		const files = event.data.files;
+		const files = this.getProcessableFiles(event);
 
 		// No files scenario - both should be empty/false
-		if (!metadata?.hasFiles && (!files || files.length === 0)) {
+		if (!metadata?.hasFiles && files.length === 0) {
 			return true;
 		}
 
 		// Has files scenario - counts should match
-		if (metadata?.hasFiles && files && files.length === metadata.fileCount) {
+		if (metadata?.hasFiles && files.length === metadata.fileCount) {
 			return true;
 		}
 
@@ -222,7 +294,7 @@ export class AttachmentDetectionService {
 		LogEngine.warn('Attachment metadata inconsistency detected', {
 			metadataHasFiles: metadata?.hasFiles,
 			metadataCount: metadata?.fileCount,
-			actualFilesCount: files?.length || 0,
+			actualFilesCount: files.length,
 			eventId: event.eventId,
 			sourcePlatform: event.sourcePlatform,
 			conversationId: event.data.conversationId,

--- a/src/services/attachmentDetection.ts
+++ b/src/services/attachmentDetection.ts
@@ -44,6 +44,22 @@ export interface AttachmentProcessingDecision {
 
 export class AttachmentDetectionService {
 	/**
+	 * Converts extension-only strings to full MIME types.
+	 * Handles cases where Unthread sends "png" instead of "image/png".
+	 * Matches the Telegram bot's normalizeType() implementation.
+	 */
+	static normalizeType(rawType: string): string {
+		const extensionMap: Record<string, string> = {
+			png: 'image/png',
+			jpg: 'image/jpeg',
+			jpeg: 'image/jpeg',
+			gif: 'image/gif',
+			webp: 'image/webp',
+		};
+		return extensionMap[rawType.toLowerCase()] ?? rawType;
+	}
+
+	/**
 	 * Primary event validation - process dashboard → discord events
 	 * Based on Telegram bot's shouldProcessEvent pattern
 	 */
@@ -71,7 +87,7 @@ export class AttachmentDetectionService {
 		}
 
 		return event.attachments?.types?.some(type =>
-			type.startsWith('image/'),
+			this.normalizeType(type).startsWith('image/'),
 		) ?? false;
 	}
 
@@ -84,7 +100,7 @@ export class AttachmentDetectionService {
 			return false;
 		}
 
-		return event.attachments?.types?.some(t => isSupportedImageType(t.toLowerCase()))
+		return event.attachments?.types?.some(t => isSupportedImageType(this.normalizeType(t).toLowerCase()))
 			?? false;
 	}
 

--- a/src/services/unthread.ts
+++ b/src/services/unthread.ts
@@ -565,8 +565,9 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 			}
 		}
 
-		// Send text content if present
-		if (messageContent.trim()) {
+		// Send text-only messages directly. When files are present, the attachment upload
+		// message carries the content so Discord receives a single combined post.
+		if (messageContent.trim() && fileCount === 0) {
 			await discordThread.send(messageContent);
 			LogEngine.info(`Sent text message to Discord thread ${discordThread.id}`);
 		}

--- a/src/services/unthread.ts
+++ b/src/services/unthread.ts
@@ -462,6 +462,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 						data.files,
 						// No text message for file-only notifications
 						undefined,
+						conversationId,
 					);
 
 					if (attachmentResult.success) {
@@ -563,6 +564,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 					discordThread,
 					data.files,
 					messageContent.trim() || undefined,
+					conversationId,
 				);
 
 				if (attachmentResult.success) {

--- a/src/services/unthread.ts
+++ b/src/services/unthread.ts
@@ -51,9 +51,10 @@ import { LogEngine } from '../config/logger';
 import { isDuplicateMessage } from '../utils/messageUtils';
 import { findDiscordThreadByTicketId, findDiscordThreadByTicketIdWithRetry } from '../utils/threadUtils';
 import { getOrCreateCustomer, getCustomerByDiscordId, Customer } from '../utils/customerUtils';
-import { WebhookPayload, UnthreadApiResponse, UnthreadTicket } from '../types/unthread';
+import { WebhookPayload, UnthreadApiResponse, UnthreadTicket, EnhancedWebhookEvent } from '../types/unthread';
 import { FileBuffer } from '../types/attachments';
 import { getConfig, DEFAULT_CONFIG } from '../config/defaults';
+import { AttachmentDetectionService } from './attachmentDetection';
 
 /**
  * ==================== ENVIRONMENT VALIDATION ====================
@@ -410,25 +411,43 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 	const conversationId = data.conversationId || data.id;
 	const messageText = data.text || data.content;
 
-	// Use pre-transformed data directly from webhook server
-	const hasFiles = data.files && data.files.length > 0;
-	const fileCount = data.files ? data.files.length : 0;
+	const attachmentEvent: EnhancedWebhookEvent = {
+		platform: 'unthread',
+		targetPlatform: 'discord',
+		type: 'message_created',
+		sourcePlatform,
+		attachments: data.attachments,
+		data: {
+			id: conversationId || data.id || 'unknown',
+			content: data.content,
+			text: data.text,
+			files: Array.isArray(data.files) ? data.files : undefined,
+			conversationId: conversationId || data.id || 'unknown',
+			userId: data.userId,
+			metadata: data.metadata,
+		},
+		timestamp: Date.now(),
+		eventId: String(data.id || data.conversationId || Date.now()),
+	};
+
+	const effectiveFiles = AttachmentDetectionService.getProcessableFiles(attachmentEvent);
+	const fileCount = effectiveFiles.length;
 
 	LogEngine.info('📋 Processing pre-transformed message data', {
 		conversationId,
-		hasFiles,
+		hasFiles: fileCount > 0,
 		fileCount,
 		hasText: !!messageText?.trim(),
 		sourcePlatform,
 	});
 
-	if (!conversationId || (!messageText?.trim() && !hasFiles)) {
+	if (!conversationId || (!messageText?.trim() && fileCount === 0)) {
 		LogEngine.warn('Message created event missing required data (must have text or files)');
 		return;
 	}
 
 	// Detect file attachment notification patterns - process files only, skip text
-	const isFileAttachedNotification = messageText && hasFiles && (
+	const isFileAttachedNotification = messageText && fileCount > 0 && (
 		messageText.trim().toLowerCase() === 'file attached' ||
 		/^\d+\s+files?\s+attached$/i.test(messageText.trim())
 	);
@@ -442,7 +461,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 		});
 
 		// Process files directly from pre-transformed data
-		if (data.files && data.files.length > 0) {
+		if (effectiveFiles.length > 0) {
 			try {
 				const { discordThread } = await findDiscordThreadByTicketIdWithRetry(
 					conversationId,
@@ -450,8 +469,8 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 				);
 
 				if (discordThread) {
-					LogEngine.info(`Processing ${data.files.length} files from pre-transformed data:`,
-						data.files.map((f: any) => ({ id: f.id, name: f.name, type: f.mimetype, size: f.size })));
+					LogEngine.info(`Processing ${effectiveFiles.length} files from pre-transformed data:`,
+						effectiveFiles.map((f: any) => ({ id: f.id, name: f.name, type: f.mimetype || f.type, size: f.size })));
 
 					// Use pre-transformed file data directly - no conversion needed
 					const { AttachmentHandler } = await import('../utils/attachmentHandler');
@@ -459,7 +478,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 
 					const attachmentResult = await attachmentHandler.downloadUnthreadFilesToDiscord(
 						discordThread,
-						data.files,
+						effectiveFiles,
 						// No text message for file-only notifications
 						undefined,
 						conversationId,
@@ -484,7 +503,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 			LogEngine.warn('File attachment notification detected but no files found in pre-transformed data', {
 				conversationId,
 				hasFiles: !!data.files,
-				filesLength: data.files?.length || 0,
+				filesLength: fileCount,
 				notificationText: messageText.trim(),
 			});
 		}
@@ -514,8 +533,8 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 		// Check for oversized files (simple size check)
 		// 8MB Discord limit
 		const maxSizeBytes = 8 * 1024 * 1024;
-		if (hasFiles && data.files) {
-			const totalSize = data.files.reduce((sum: number, file: any) => sum + (file.size || 0), 0);
+		if (fileCount > 0) {
+			const totalSize = effectiveFiles.reduce((sum: number, file: any) => sum + (file.size || 0), 0);
 			if (totalSize > maxSizeBytes) {
 				await handleOversizedFiles(discordThread, totalSize, maxSizeBytes);
 				return;
@@ -553,8 +572,8 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 		}
 
 		// Process files if present
-		if (hasFiles && data.files && data.files.length > 0) {
-			LogEngine.info(`Processing ${data.files.length} files from pre-transformed data`);
+		if (fileCount > 0) {
+			LogEngine.info(`Processing ${fileCount} files from pre-transformed data`);
 
 			const { AttachmentHandler } = await import('../utils/attachmentHandler');
 			const attachmentHandler = new AttachmentHandler();
@@ -562,7 +581,7 @@ async function handleMessageCreated(data: any, sourcePlatform: string): Promise<
 			try {
 				const attachmentResult = await attachmentHandler.downloadUnthreadFilesToDiscord(
 					discordThread,
-					data.files,
+					effectiveFiles,
 					messageContent.trim() || undefined,
 					conversationId,
 				);

--- a/src/services/unthread.ts
+++ b/src/services/unthread.ts
@@ -379,10 +379,11 @@ export async function handleWebhookEvent(payload: WebhookPayload): Promise<void>
  * @returns {Promise<void>}
  */
 async function handleMessageCreated(data: any, sourcePlatform: string): Promise<void> {
-	// Check if message originated from Discord to avoid duplication
-	// The webhook server provides sourcePlatform for reliable source detection
-	if (sourcePlatform === 'discord') {
-		LogEngine.debug('Message originated from Discord, skipping to avoid duplication', {
+	// Only process messages from the Unthread dashboard (agent/human replies).
+	// Skipping all other sources (discord, unknown, buffered) prevents duplication
+	// and avoids processing unresolved/correlated webhook events.
+	if (sourcePlatform !== 'dashboard') {
+		LogEngine.debug('Message did not originate from dashboard, skipping', {
 			sourcePlatform,
 			conversationId: data.conversationId || data.id,
 		});

--- a/src/utils/attachmentHandler.ts
+++ b/src/utils/attachmentHandler.ts
@@ -385,6 +385,13 @@ export class AttachmentHandler {
 
 				if (RETRYABLE_STATUS_CODES.includes(response.status) && attempt < FILE_DOWNLOAD_MAX_RETRIES) {
 					LogEngine.debug(`Retrying ${label} (attempt ${attempt}/${FILE_DOWNLOAD_MAX_RETRIES}) due to status ${response.status}`);
+					// Drain the response body to release the underlying socket before retrying
+					try {
+						await response.arrayBuffer();
+					}
+					catch {
+						// Ignore drain errors; connection will be cleaned up eventually
+					}
 					await new Promise(resolve => setTimeout(resolve, FILE_DOWNLOAD_RETRY_DELAY_MS));
 					continue;
 				}

--- a/src/utils/attachmentHandler.ts
+++ b/src/utils/attachmentHandler.ts
@@ -52,11 +52,36 @@ import { AttachmentDetectionService } from '../services/attachmentDetection';
 import { LogEngine } from '../config/logger';
 
 export class AttachmentHandler {
+	private static readonly UNTHREAD_API_BASE_URL = 'https://api.unthread.io/api';
+	private static readonly RETRYABLE_STATUS_CODES = [404, 409, 425];
+	private static readonly FILE_DOWNLOAD_MAX_RETRIES = 8;
+	private static readonly FILE_DOWNLOAD_RETRY_DELAY_MS = 1000;
+
 	/**
 	 * Type guard to check if content type is supported
 	 */
 	private isSupportedImageType(contentType: string): boolean {
 		return (DISCORD_ATTACHMENT_CONFIG.supportedImageTypes as readonly string[]).includes(contentType);
+	}
+
+	private isUnthreadApiUrl(downloadUrl: string): boolean {
+		try {
+			const target = new URL(downloadUrl);
+			const apiOrigin = new URL(AttachmentHandler.UNTHREAD_API_BASE_URL);
+			return target.origin === apiOrigin.origin;
+		}
+		catch {
+			return false;
+		}
+	}
+
+	private getFileName(file: any, fallback = 'unknown-file'): string {
+		return file.name || file.title || file.filename || fallback;
+	}
+
+	private getFileMimeType(file: any): string {
+		const rawType = file.mimetype || file.contentType || file.type || file.filetype || 'application/octet-stream';
+		return AttachmentDetectionService.normalizeType(rawType);
 	}
 
 	/**
@@ -275,6 +300,7 @@ export class AttachmentHandler {
 		discordThread: ThreadChannel,
 		files: any[],
 		messageContent?: string,
+		conversationId?: string,
 	): Promise<AttachmentProcessingResult> {
 		const startTime = Date.now();
 		const errors: string[] = [];
@@ -296,7 +322,7 @@ export class AttachmentHandler {
 			// Download files to buffers
 			const fileBuffers: FileBuffer[] = [];
 			const downloadPromises = files.map(file =>
-				this.downloadFileFromUnthread(file),
+				this.downloadFileFromUnthread(file, conversationId),
 			);
 
 			const downloadResults = await Promise.allSettled(downloadPromises);
@@ -358,10 +384,6 @@ export class AttachmentHandler {
 			};
 		}
 	}
-
-	private static readonly RETRYABLE_STATUS_CODES = [404, 409, 425];
-	private static readonly FILE_DOWNLOAD_MAX_RETRIES = 8;
-	private static readonly FILE_DOWNLOAD_RETRY_DELAY_MS = 1000;
 
 	private async drainResponseBody(response: Response): Promise<void> {
 		try {
@@ -426,7 +448,9 @@ export class AttachmentHandler {
 	/**
 	 * Download a single file from Unthread using pre-transformed file data
 	 */
-	private async downloadFileFromUnthread(file: any): Promise<FileBuffer> {
+	private async downloadFileFromUnthread(file: any, conversationId?: string): Promise<FileBuffer> {
+		const fileName = this.getFileName(file);
+
 		// Check if this is a Slack file (ID starts with 'F' and has the right structure)
 		const isSlackFile = file.id &&
 			typeof file.id === 'string' &&
@@ -436,12 +460,12 @@ export class AttachmentHandler {
 		if (isSlackFile) {
 			LogEngine.info('Detected Slack file, using thumbnail endpoint', {
 				fileId: file.id,
-				fileName: file.name,
+				fileName,
 			});
 
 			return this.downloadUnthreadSlackFile(
 				file.id,
-				file.name,
+				fileName,
 				file.size,
 			);
 		}
@@ -449,35 +473,115 @@ export class AttachmentHandler {
 		// For non-Slack files, use direct URL if available
 		if (file.urlPrivateDownload || file.urlPrivate) {
 			const downloadUrl = file.urlPrivateDownload || file.urlPrivate;
-			LogEngine.debug(`Using direct URL download for: ${file.name} from ${downloadUrl}`);
-
-			const apiKey = process.env.UNTHREAD_API_KEY!;
-			const response = await this.fetchWithRetry(
-				downloadUrl,
-				{ 'X-API-KEY': apiKey, 'User-Agent': 'unthread-discord-bot' },
-				file.name,
-			);
-
-			if (!response.ok) {
-				await this.drainResponseBody(response);
-				throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
+			if (!this.isUnthreadApiUrl(downloadUrl)) {
+				LogEngine.warn('Ignoring non-Unthread direct download URL from webhook payload', {
+					fileName,
+					hasFileId: !!file.id,
+				});
 			}
+			else {
+				LogEngine.debug(`Using direct URL download for: ${fileName} from ${downloadUrl}`);
 
-			const arrayBuffer = await response.arrayBuffer();
-			const buffer = Buffer.from(arrayBuffer);
+				const apiKey = process.env.UNTHREAD_API_KEY!;
+				const response = await this.fetchWithRetry(
+					downloadUrl,
+					{ 'X-API-KEY': apiKey, 'User-Agent': 'unthread-discord-bot' },
+					fileName,
+				);
 
-			const fileBuffer: FileBuffer = {
-				buffer,
-				fileName: file.name,
-				mimeType: file.mimetype || file.contentType || 'application/octet-stream',
-				size: buffer.length,
-			};
+				if (!response.ok) {
+					await this.drainResponseBody(response);
+					throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
+				}
 
-			LogEngine.debug(`Downloaded ${file.name}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
-			return fileBuffer;
+				const arrayBuffer = await response.arrayBuffer();
+				const buffer = Buffer.from(arrayBuffer);
+
+				const fileBuffer: FileBuffer = {
+					buffer,
+					fileName,
+					mimeType: this.getFileMimeType(file),
+					size: buffer.length,
+				};
+
+				LogEngine.debug(`Downloaded ${fileName}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
+				return fileBuffer;
+			}
 		}
 
-		throw new Error(`No download method available for file: ${file.name}`);
+		if (conversationId && file.id && typeof file.id === 'string') {
+			return this.downloadUnthreadConversationFile(
+				conversationId,
+				file.id,
+				fileName,
+				file.size,
+				this.getFileMimeType(file),
+			);
+		}
+
+		throw new Error(`No download method available for file: ${fileName}`);
+	}
+
+	private async downloadUnthreadConversationFile(
+		conversationId: string,
+		fileId: string,
+		fileName: string,
+		fileSize: number,
+		mimeType: string,
+	): Promise<FileBuffer> {
+		LogEngine.info('Starting conversation-scoped Unthread file download', {
+			conversationId,
+			fileId,
+			fileName,
+			fileSize,
+			method: 'conversation-file-endpoint',
+		});
+
+		const apiKey = process.env.UNTHREAD_API_KEY!;
+		const endpoint = `${AttachmentHandler.UNTHREAD_API_BASE_URL}/conversations/${encodeURIComponent(conversationId)}/files/${encodeURIComponent(fileId)}/full`;
+		const response = await this.fetchWithRetry(
+			endpoint,
+			{ 'X-API-KEY': apiKey, 'User-Agent': 'unthread-discord-bot' },
+			fileName,
+		);
+
+		if (!response.ok) {
+			await this.drainResponseBody(response);
+			throw new Error(`Failed to download conversation file: ${response.status} ${response.statusText}`);
+		}
+
+		const arrayBuffer = await response.arrayBuffer();
+		const buffer = Buffer.from(arrayBuffer);
+
+		if (buffer.length === 0) {
+			throw new Error('Downloaded file is empty');
+		}
+
+		const maxSize = DISCORD_ATTACHMENT_CONFIG.maxFileSize;
+		if (buffer.length > maxSize) {
+			throw new Error(`File too large: ${buffer.length} bytes (max: ${maxSize})`);
+		}
+
+		if (fileSize && buffer.length !== fileSize) {
+			LogEngine.warn(`Size mismatch for ${fileName}: expected ${fileSize}, got ${buffer.length}`);
+		}
+
+		const fileBuffer: FileBuffer = {
+			buffer,
+			fileName,
+			mimeType,
+			size: buffer.length,
+		};
+
+		LogEngine.info('Conversation-scoped Unthread file download successful', {
+			conversationId,
+			fileId,
+			fileName,
+			downloadedSize: buffer.length,
+			contentType: fileBuffer.mimeType,
+		});
+
+		return fileBuffer;
 	}
 
 	/**

--- a/src/utils/attachmentHandler.ts
+++ b/src/utils/attachmentHandler.ts
@@ -363,6 +363,15 @@ export class AttachmentHandler {
 	private static readonly FILE_DOWNLOAD_MAX_RETRIES = 8;
 	private static readonly FILE_DOWNLOAD_RETRY_DELAY_MS = 1000;
 
+	private async drainResponseBody(response: Response): Promise<void> {
+		try {
+			await response.arrayBuffer();
+		}
+		catch {
+			// Ignore drain errors; connection will be cleaned up eventually
+		}
+	}
+
 	/**
 	 * Fetch a URL with retry logic for transient Unthread file availability errors.
 	 * Unthread files may not be immediately available after upload, so we retry
@@ -374,6 +383,8 @@ export class AttachmentHandler {
 		label: string,
 	): Promise<Response> {
 		const { RETRYABLE_STATUS_CODES, FILE_DOWNLOAD_MAX_RETRIES, FILE_DOWNLOAD_RETRY_DELAY_MS } = AttachmentHandler;
+		let lastRetryableStatus: number | undefined;
+		let lastRetryableStatusText = '';
 
 		for (let attempt = 1; attempt <= FILE_DOWNLOAD_MAX_RETRIES; attempt++) {
 			const controller = new AbortController();
@@ -383,17 +394,18 @@ export class AttachmentHandler {
 				const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
 				clearTimeout(timeoutId);
 
-				if (RETRYABLE_STATUS_CODES.includes(response.status) && attempt < FILE_DOWNLOAD_MAX_RETRIES) {
-					LogEngine.debug(`Retrying ${label} (attempt ${attempt}/${FILE_DOWNLOAD_MAX_RETRIES}) due to status ${response.status}`);
-					// Drain the response body to release the underlying socket before retrying
-					try {
-						await response.arrayBuffer();
+				if (RETRYABLE_STATUS_CODES.includes(response.status)) {
+					await this.drainResponseBody(response);
+					lastRetryableStatus = response.status;
+					lastRetryableStatusText = response.statusText;
+
+					if (attempt < FILE_DOWNLOAD_MAX_RETRIES) {
+						LogEngine.debug(`Retrying ${label} (attempt ${attempt}/${FILE_DOWNLOAD_MAX_RETRIES}) due to status ${response.status}`);
+						await new Promise(resolve => setTimeout(resolve, FILE_DOWNLOAD_RETRY_DELAY_MS));
+						continue;
 					}
-					catch {
-						// Ignore drain errors; connection will be cleaned up eventually
-					}
-					await new Promise(resolve => setTimeout(resolve, FILE_DOWNLOAD_RETRY_DELAY_MS));
-					continue;
+
+					break;
 				}
 
 				return response;
@@ -407,7 +419,8 @@ export class AttachmentHandler {
 			}
 		}
 
-		throw new Error(`Failed to download ${label} after ${FILE_DOWNLOAD_MAX_RETRIES} attempts`);
+		const statusDetails = lastRetryableStatus ? `: ${lastRetryableStatus} ${lastRetryableStatusText}` : '';
+		throw new Error(`Failed to download ${label} after ${FILE_DOWNLOAD_MAX_RETRIES} attempts${statusDetails}`);
 	}
 
 	/**
@@ -446,6 +459,7 @@ export class AttachmentHandler {
 			);
 
 			if (!response.ok) {
+				await this.drainResponseBody(response);
 				throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
 			}
 
@@ -755,6 +769,7 @@ export class AttachmentHandler {
 		);
 
 		if (!response.ok) {
+			await this.drainResponseBody(response);
 			throw new Error(`Failed to download Unthread attachment: ${response.status} ${response.statusText}`);
 		}
 

--- a/src/utils/attachmentHandler.ts
+++ b/src/utils/attachmentHandler.ts
@@ -359,6 +359,50 @@ export class AttachmentHandler {
 		}
 	}
 
+	private static readonly RETRYABLE_STATUS_CODES = [404, 409, 425];
+	private static readonly FILE_DOWNLOAD_MAX_RETRIES = 8;
+	private static readonly FILE_DOWNLOAD_RETRY_DELAY_MS = 1000;
+
+	/**
+	 * Fetch a URL with retry logic for transient Unthread file availability errors.
+	 * Unthread files may not be immediately available after upload, so we retry
+	 * on HTTP 404, 409, and 425 (matching the Telegram bot's proven pattern).
+	 */
+	private async fetchWithRetry(
+		url: string,
+		headers: Record<string, string>,
+		label: string,
+	): Promise<Response> {
+		const { RETRYABLE_STATUS_CODES, FILE_DOWNLOAD_MAX_RETRIES, FILE_DOWNLOAD_RETRY_DELAY_MS } = AttachmentHandler;
+
+		for (let attempt = 1; attempt <= FILE_DOWNLOAD_MAX_RETRIES; attempt++) {
+			const controller = new AbortController();
+			const timeoutId = setTimeout(() => controller.abort(), DISCORD_ATTACHMENT_CONFIG.uploadTimeout);
+
+			try {
+				const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
+				clearTimeout(timeoutId);
+
+				if (RETRYABLE_STATUS_CODES.includes(response.status) && attempt < FILE_DOWNLOAD_MAX_RETRIES) {
+					LogEngine.debug(`Retrying ${label} (attempt ${attempt}/${FILE_DOWNLOAD_MAX_RETRIES}) due to status ${response.status}`);
+					await new Promise(resolve => setTimeout(resolve, FILE_DOWNLOAD_RETRY_DELAY_MS));
+					continue;
+				}
+
+				return response;
+			}
+			catch (error: unknown) {
+				clearTimeout(timeoutId);
+				if (error instanceof Error && error.name === 'AbortError') {
+					throw new Error(`Download timeout for ${label} after ${DISCORD_ATTACHMENT_CONFIG.uploadTimeout}ms`);
+				}
+				throw error;
+			}
+		}
+
+		throw new Error(`Failed to download ${label} after ${FILE_DOWNLOAD_MAX_RETRIES} attempts`);
+	}
+
 	/**
 	 * Download a single file from Unthread using pre-transformed file data
 	 */
@@ -387,49 +431,29 @@ export class AttachmentHandler {
 			const downloadUrl = file.urlPrivateDownload || file.urlPrivate;
 			LogEngine.debug(`Using direct URL download for: ${file.name} from ${downloadUrl}`);
 
-			const controller = new AbortController();
-			const timeoutId = setTimeout(() => controller.abort(), DISCORD_ATTACHMENT_CONFIG.uploadTimeout);
+			const apiKey = process.env.UNTHREAD_API_KEY!;
+			const response = await this.fetchWithRetry(
+				downloadUrl,
+				{ 'X-API-KEY': apiKey, 'User-Agent': 'unthread-discord-bot' },
+				file.name,
+			);
 
-			try {
-				const apiKey = process.env.UNTHREAD_API_KEY!;
-
-				const response = await fetch(downloadUrl, {
-					method: 'GET',
-					headers: {
-						'X-API-KEY': apiKey,
-						'User-Agent': 'unthread-discord-bot',
-					},
-					signal: controller.signal,
-				});
-
-				if (!response.ok) {
-					throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
-				}
-
-				const arrayBuffer = await response.arrayBuffer();
-				const buffer = Buffer.from(arrayBuffer);
-
-				const fileBuffer: FileBuffer = {
-					buffer,
-					fileName: file.name,
-					mimeType: file.mimetype || file.contentType || 'application/octet-stream',
-					size: buffer.length,
-				};
-
-				LogEngine.debug(`Downloaded ${file.name}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
-				return fileBuffer;
-
+			if (!response.ok) {
+				throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
 			}
-			catch (error: unknown) {
-				const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-				if (error instanceof Error && error.name === 'AbortError') {
-					throw new Error(`Download timeout for ${file.name} after ${DISCORD_ATTACHMENT_CONFIG.uploadTimeout}ms`);
-				}
-				throw new Error(`Failed to download ${file.name}: ${errorMessage}`);
-			}
-			finally {
-				clearTimeout(timeoutId);
-			}
+
+			const arrayBuffer = await response.arrayBuffer();
+			const buffer = Buffer.from(arrayBuffer);
+
+			const fileBuffer: FileBuffer = {
+				buffer,
+				fileName: file.name,
+				mimeType: file.mimetype || file.contentType || 'application/octet-stream',
+				size: buffer.length,
+			};
+
+			LogEngine.debug(`Downloaded ${file.name}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
+			return fileBuffer;
 		}
 
 		throw new Error(`No download method available for file: ${file.name}`);
@@ -610,93 +634,71 @@ export class AttachmentHandler {
 				teamId: teamId,
 			});
 
-			const controller = new AbortController();
-			const timeoutId = setTimeout(() => controller.abort(), DISCORD_ATTACHMENT_CONFIG.uploadTimeout);
+			LogEngine.debug('Making Unthread Slack file API request', {
+				endpoint,
+				params: { thumbSize: '160', teamId: teamId.substring(0, 8) + '...' },
+				hasApiKey: !!apiKey,
+			});
 
-			try {
-				LogEngine.debug('Making Unthread Slack file API request', {
-					endpoint,
-					params: { thumbSize: '160', teamId: teamId.substring(0, 8) + '...' },
-					hasApiKey: !!apiKey,
-				});
+			const response = await this.fetchWithRetry(
+				`${endpoint}?${params.toString()}`,
+				{ 'X-API-KEY': apiKey, 'Accept': '*/*', 'User-Agent': 'unthread-discord-bot' },
+				`Slack file ${fileId}`,
+			);
 
-				const response = await fetch(`${endpoint}?${params.toString()}`, {
-					method: 'GET',
-					headers: {
-						'X-API-KEY': apiKey,
-						'Accept': '*/*',
-						'User-Agent': 'unthread-discord-bot',
-					},
-					signal: controller.signal,
-				});
-
-				if (!response.ok) {
-					let errorMessage = `Unthread Slack file API error: ${response.status} ${response.statusText}`;
-					try {
-						const errorBody = await response.text();
-						if (errorBody) {
-							errorMessage += ` - Response: ${errorBody}`;
-						}
+			if (!response.ok) {
+				let errorMessage = `Unthread Slack file API error: ${response.status} ${response.statusText}`;
+				try {
+					const errorBody = await response.text();
+					if (errorBody) {
+						errorMessage += ` - Response: ${errorBody}`;
 					}
-					catch (bodyError) {
-						LogEngine.warn('Failed to read error response body', { bodyError });
-					}
-					throw new Error(errorMessage);
 				}
-
-				// Validate content type
-				const contentType = response.headers.get('content-type') || '';
-				LogEngine.debug('Received response', {
-					fileId,
-					status: response.status,
-					contentType,
-					contentLength: response.headers.get('content-length'),
-				});
-
-				// Get response as buffer
-				const arrayBuffer = await response.arrayBuffer();
-				const buffer = Buffer.from(arrayBuffer);
-
-				if (buffer.length === 0) {
-					throw new Error('Downloaded file is empty');
+				catch (bodyError) {
+					LogEngine.warn('Failed to read error response body', { bodyError });
 				}
-
-				// Validate size against Discord limits
-				const maxSize = DISCORD_ATTACHMENT_CONFIG.maxFileSize;
-				if (buffer.length > maxSize) {
-					throw new Error(`File too large: ${buffer.length} bytes (max: ${maxSize})`);
-				}
-
-				const fileBuffer: FileBuffer = {
-					buffer,
-					fileName,
-					mimeType: contentType || 'application/octet-stream',
-					size: buffer.length,
-				};
-
-				LogEngine.info('Slack file download successful', {
-					fileId,
-					fileName,
-					downloadedSize: buffer.length,
-					expectedSize: fileSize,
-					contentType: fileBuffer.mimeType,
-				});
-
-				return fileBuffer;
-
+				throw new Error(errorMessage);
 			}
-			catch (fetchError: unknown) {
-				clearTimeout(timeoutId);
 
-				if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-					throw new Error(`Slack file download timeout after ${DISCORD_ATTACHMENT_CONFIG.uploadTimeout}ms`);
-				}
+			// Validate content type
+			const contentType = response.headers.get('content-type') || '';
+			LogEngine.debug('Received response', {
+				fileId,
+				status: response.status,
+				contentType,
+				contentLength: response.headers.get('content-length'),
+			});
 
-				throw fetchError;
+			// Get response as buffer
+			const arrayBuffer = await response.arrayBuffer();
+			const buffer = Buffer.from(arrayBuffer);
+
+			if (buffer.length === 0) {
+				throw new Error('Downloaded file is empty');
 			}
-			finally {
-				clearTimeout(timeoutId);
+
+			// Validate size against Discord limits
+			const maxSize = DISCORD_ATTACHMENT_CONFIG.maxFileSize;
+			if (buffer.length > maxSize) {
+				throw new Error(`File too large: ${buffer.length} bytes (max: ${maxSize})`);
 			}
+
+			const fileBuffer: FileBuffer = {
+				buffer,
+				fileName,
+				mimeType: contentType || 'application/octet-stream',
+				size: buffer.length,
+			};
+
+			LogEngine.info('Slack file download successful', {
+				fileId,
+				fileName,
+				downloadedSize: buffer.length,
+				expectedSize: fileSize,
+				contentType: fileBuffer.mimeType,
+			});
+
+			return fileBuffer;
 
 		}
 		catch (error: unknown) {
@@ -738,56 +740,35 @@ export class AttachmentHandler {
 		// Fallback to direct URL download for non-Slack files
 		LogEngine.debug(`Using direct URL download for: ${unthreadAttachment.filename} from ${unthreadAttachment.url}`);
 
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), DISCORD_ATTACHMENT_CONFIG.uploadTimeout);
+		const apiKey = process.env.UNTHREAD_API_KEY!;
+		const response = await this.fetchWithRetry(
+			unthreadAttachment.url,
+			{ 'X-API-KEY': apiKey, 'User-Agent': 'unthread-discord-bot' },
+			unthreadAttachment.filename,
+		);
 
-		try {
-			// Get API key (guaranteed to exist due to startup validation)
-			const apiKey = process.env.UNTHREAD_API_KEY!;
-
-			const response = await fetch(unthreadAttachment.url, {
-				method: 'GET',
-				headers: {
-					'X-API-KEY': apiKey,
-					'User-Agent': 'unthread-discord-bot',
-				},
-				signal: controller.signal,
-			});
-
-			if (!response.ok) {
-				throw new Error(`Failed to download Unthread attachment: ${response.status} ${response.statusText}`);
-			}
-
-			// Get response as array buffer first
-			const arrayBuffer = await response.arrayBuffer();
-			const buffer = Buffer.from(arrayBuffer);
-
-			// Verify downloaded size matches expected size
-			if (buffer.length !== unthreadAttachment.size) {
-				LogEngine.warn(`Size mismatch for ${unthreadAttachment.filename}: expected ${unthreadAttachment.size}, got ${buffer.length}`);
-			}
-
-			const fileBuffer: FileBuffer = {
-				buffer,
-				fileName: unthreadAttachment.filename,
-				mimeType: unthreadAttachment.content_type,
-				size: buffer.length,
-			};
-
-			LogEngine.debug(`Downloaded ${unthreadAttachment.filename}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
-			return fileBuffer;
-
+		if (!response.ok) {
+			throw new Error(`Failed to download Unthread attachment: ${response.status} ${response.statusText}`);
 		}
-		catch (error: unknown) {
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-			if (error instanceof Error && error.name === 'AbortError') {
-				throw new Error(`Download timeout for ${unthreadAttachment.filename} after ${DISCORD_ATTACHMENT_CONFIG.uploadTimeout}ms`);
-			}
-			throw new Error(`Failed to download ${unthreadAttachment.filename}: ${errorMessage}`);
+
+		// Get response as array buffer first
+		const arrayBuffer = await response.arrayBuffer();
+		const buffer = Buffer.from(arrayBuffer);
+
+		// Verify downloaded size matches expected size
+		if (buffer.length !== unthreadAttachment.size) {
+			LogEngine.warn(`Size mismatch for ${unthreadAttachment.filename}: expected ${unthreadAttachment.size}, got ${buffer.length}`);
 		}
-		finally {
-			clearTimeout(timeoutId);
-		}
+
+		const fileBuffer: FileBuffer = {
+			buffer,
+			fileName: unthreadAttachment.filename,
+			mimeType: unthreadAttachment.content_type,
+			size: buffer.length,
+		};
+
+		LogEngine.debug(`Downloaded ${unthreadAttachment.filename}: ${buffer.length} bytes, MIME: ${fileBuffer.mimeType}`);
+		return fileBuffer;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Aligns the Discord bot's attachment handling with:
- **[unthread-webhook-server](https://github.com/wgtechlabs/unthread-webhook-server) (dev branch)** - ensures compatibility with the new webhook payload structure and sourcePlatform values
- **[unthread-telegram-bot](https://github.com/wgtechlabs/unthread-telegram-bot) (dev branch)** - achieves feature parity on retry logic and MIME normalization

## Changes

### src/utils/attachmentHandler.ts
- Added fetchWithRetry() private method - 8 attempts, 1s delay between retries, retries on HTTP 404/409/425 (transient Unthread CDN states)
- Added response body drain (response.arrayBuffer() in try/catch) before each retry to release the underlying socket and prevent connection pool exhaustion
- Refactored downloadFileFromUnthread, downloadUnthreadSlackFile, and downloadUnthreadAttachmentToBuffer to use fetchWithRetry() instead of single-attempt fetch

### src/services/attachmentDetection.ts
- Added normalizeType() static method that maps extension-like values (png, jpg, jpeg, gif, webp) to full MIME types
- Updated hasImageAttachments() and hasSupportedImages() to call normalizeType() before type checks - handles cases where the webhook server emits file.filetype instead of file.mimetype

### src/services/unthread.ts
- Fixed sourcePlatform guard in handleMessageCreated(): changed === 'discord' to !== 'dashboard'
- The webhook server emits sourcePlatform: 'unknown' for file events that time out correlation; the old guard would incorrectly process those events

## Testing
- All 184 tests pass, 21 skipped (timing-based, by design)
- ESLint: 0 errors on changed files (25 pre-existing any/injection warnings, unrelated)

## References
- Mirrors fetchUnthreadFileWithRetry() pattern from unthread-telegram-bot dev branch
- Compatible with RedisQueueMessage shape from unthread-webhook-server dev branch
