### PR TITLE
🔧 update: improve ticket creation UX with in-place status embed

### DIFF
--- a/src/events/threadCreate.ts
+++ b/src/events/threadCreate.ts
@@ -163,14 +163,11 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 			.setTimestamp();
 
 		try {
-			statusMessage = await withRetry(
-				async () => thread.send({ embeds: [processingEmbed] }),
-				{
-					operationName: 'Send processing status message',
-					maxAttempts: 3,
-					baseDelayMs: 1000,
-				},
-			);
+			statusMessage = await withRetry(async () => thread.send({ embeds: [processingEmbed] }), {
+				operationName: 'Send processing status message',
+				maxAttempts: 3,
+				baseDelayMs: 1000,
+			});
 		} catch (statusError: unknown) {
 			const statusErrorMessage =
 				statusError instanceof Error ? statusError.message : String(statusError);

--- a/src/events/threadCreate.ts
+++ b/src/events/threadCreate.ts
@@ -150,8 +150,20 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 
 	// Declare in higher scope for error logging access
 	let firstMessage: Message | undefined;
+	let statusMessage: Message | undefined;
 
 	try {
+		const processingEmbed = new EmbedBuilder()
+			.setColor(0xffc107)
+			.setTitle('⏳ Creating your support ticket')
+			.setDescription(
+				'We received your forum post and are creating your ticket in Unthread. This can take a few moments.',
+			)
+			.setFooter({ text: getBotFooter() })
+			.setTimestamp();
+
+		statusMessage = await thread.send({ embeds: [processingEmbed] });
+
 		// Fetch the first message with our retry mechanism
 		firstMessage = await withRetry(
 			async () => {
@@ -234,7 +246,11 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 			.setFooter({ text: getBotFooter() })
 			.setTimestamp();
 
-		await thread.send({ embeds: [ticketEmbed] });
+		if (statusMessage) {
+			await statusMessage.edit({ embeds: [ticketEmbed] });
+		} else {
+			await thread.send({ embeds: [ticketEmbed] });
+		}
 
 		LogEngine.info(`Forum post converted to ticket: #${ticket.friendlyId}`);
 	} catch (error: unknown) {
@@ -271,7 +287,11 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 					.setFooter({ text: getBotFooter() })
 					.setTimestamp();
 
-				await thread.send({ embeds: [errorEmbed] });
+				if (statusMessage) {
+					await statusMessage.edit({ embeds: [errorEmbed] });
+				} else {
+					await thread.send({ embeds: [errorEmbed] });
+				}
 				LogEngine.info('Sent error notification to user in thread');
 			} else {
 				LogEngine.warn('Cannot send error message to user - missing permissions');

--- a/src/events/threadCreate.ts
+++ b/src/events/threadCreate.ts
@@ -162,7 +162,22 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 			.setFooter({ text: getBotFooter() })
 			.setTimestamp();
 
-		statusMessage = await thread.send({ embeds: [processingEmbed] });
+		try {
+			statusMessage = await withRetry(
+				async () => thread.send({ embeds: [processingEmbed] }),
+				{
+					operationName: 'Send processing status message',
+					maxAttempts: 3,
+					baseDelayMs: 1000,
+				},
+			);
+		} catch (statusError: unknown) {
+			const statusErrorMessage =
+				statusError instanceof Error ? statusError.message : String(statusError);
+			LogEngine.warn(
+				`Could not send processing status message; continuing ticket creation flow: ${statusErrorMessage}`,
+			);
+		}
 
 		// Fetch the first message with our retry mechanism
 		firstMessage = await withRetry(
@@ -247,7 +262,15 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 			.setTimestamp();
 
 		if (statusMessage) {
-			await statusMessage.edit({ embeds: [ticketEmbed] });
+			try {
+				await statusMessage.edit({ embeds: [ticketEmbed] });
+			} catch (editError: unknown) {
+				const editErrorMessage = editError instanceof Error ? editError.message : String(editError);
+				LogEngine.warn(
+					`Could not edit processing status message with success embed; sending new message instead: ${editErrorMessage}`,
+				);
+				await thread.send({ embeds: [ticketEmbed] });
+			}
 		} else {
 			await thread.send({ embeds: [ticketEmbed] });
 		}
@@ -288,7 +311,16 @@ export async function execute(thread: ThreadChannel): Promise<void> {
 					.setTimestamp();
 
 				if (statusMessage) {
-					await statusMessage.edit({ embeds: [errorEmbed] });
+					try {
+						await statusMessage.edit({ embeds: [errorEmbed] });
+					} catch (editError: unknown) {
+						const editErrorMessage =
+							editError instanceof Error ? editError.message : String(editError);
+						LogEngine.warn(
+							`Could not edit processing status message with error embed; sending new message instead: ${editErrorMessage}`,
+						);
+						await thread.send({ embeds: [errorEmbed] });
+					}
 				} else {
 					await thread.send({ embeds: [errorEmbed] });
 				}


### PR DESCRIPTION
## Summary
Improves the user-facing feedback during support ticket creation by sending an immediate "processing" embed when a forum thread is created, then editing that same message in-place once the ticket is fully created (or if an error occurs). This eliminates the awkward gap where users see no feedback while the bot processes their post, replacing it with a clear loading state.

## Changes
- Send a `⏳ Creating your support ticket` processing embed immediately upon thread creation
- Replace the final success embed `send` with an in-place `edit` of the processing message
- Replace the error embed `send` with an in-place `edit` of the processing message
- Fall back to sending a new message if the initial status message was never set (defensive guard)

## Test Plan
- Create a new forum post and verify the yellow processing embed appears immediately
- Confirm the processing embed is edited in-place to the success ticket embed upon completion
- Simulate an error condition (e.g. Unthread API failure) and confirm the processing embed is edited in-place to the error embed
- Verify the fallback `thread.send` path still works if `statusMessage` is undefined