### PR TITLE
🗑️ remove (deps): drop stale keyv packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,12 @@
     "": {
       "name": "unthread-discord-bot",
       "dependencies": {
-        "@keyv/redis": "^5.1.6",
         "@types/ioredis": "^5.0.0",
         "@wgtechlabs/log-engine": "2.3.1",
-        "cacheable": "^2.3.5",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ioredis": "^5.10.1",
-        "keyv": "^5.6.0",
         "pg": "^8.21.0",
         "redis": "^6.0.1",
       },
@@ -48,10 +45,6 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
-
-    "@cacheable/memory": ["@cacheable/memory@2.0.8", "", { "dependencies": { "@cacheable/utils": "^2.4.0", "@keyv/bigmap": "^1.3.1", "hookified": "^1.15.1", "keyv": "^5.6.0" } }, "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw=="],
-
-    "@cacheable/utils": ["@cacheable/utils@2.4.1", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -127,15 +120,9 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
-
-    "@keyv/redis": ["@keyv/redis@5.1.6", "", { "dependencies": { "@redis/client": "^5.10.0", "cluster-key-slot": "^1.1.2", "hookified": "^1.13.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-eKvW6pspvVaU5dxigaIDZr635/Uw6urTXL3gNbY9WTR8d3QigZQT+r8gxYSEOsw4+1cCBsC4s7T2ptR0WC9LfQ=="],
-
-    "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
-
     "@redis/bloom": ["@redis/bloom@6.1.0", "", { "peerDependencies": { "@redis/client": "^6.1.0" } }, "sha512-Rzascjd9J9bJsM45T/Z9CTg1QY/B63B6YO8QorLVMeXnbBDsKiSCVR/+GQ061hYPk8FpTzWmPY8tAv2sT+JEtQ=="],
 
-    "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
+    "@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
 
     "@redis/json": ["@redis/json@6.1.0", "", { "peerDependencies": { "@redis/client": "^6.1.0" } }, "sha512-/GFjQA6bu5pG9ClCJAI5Xx4bNXe7UTpxBBlIupBNTrn1+nY860apGnYJuaSCDV2BmEbTidpa7O2qa28oxKx+rg=="],
 
@@ -212,8 +199,6 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "cacheable": ["cacheable@2.3.5", "", { "dependencies": { "@cacheable/memory": "^2.0.8", "@cacheable/utils": "^2.4.1", "hookified": "^1.15.0", "keyv": "^5.6.0", "qified": "^0.10.1" } }, "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -293,11 +278,7 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
-    "hashery": ["hashery@1.5.1", "", { "dependencies": { "hookified": "^1.15.0" } }, "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ=="],
-
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
-
-    "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -320,8 +301,6 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
-    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -394,8 +373,6 @@
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "pstree.remy": ["pstree.remy@1.1.8", "", {}, "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="],
-
-    "qified": ["qified@0.10.1", "", { "dependencies": { "hookified": "^2.1.1" } }, "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
@@ -483,14 +460,6 @@
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
-    "@redis/bloom/@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
-
-    "@redis/json/@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
-
-    "@redis/search/@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
-
-    "@redis/time-series/@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
-
     "@types/body-parser/@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "@types/connect/@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
@@ -508,10 +477,6 @@
     "bun-types/@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "pg/pg-protocol": ["pg-protocol@1.14.0", "", {}, "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="],
-
-    "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
-
-    "redis/@redis/client": ["@redis/client@6.1.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,67 +1,67 @@
 {
-  "name": "unthread-discord-bot",
-  "description": "Turn Discord community servers into real-time support ticket hubs — powered by Unthread.io",
-  "version": "1.1.5",
-  "private": true,
-  "main": "dist/index.js",
-  "scripts": {
-    "build": "tsc",
-    "type-check": "tsc --noEmit",
-    "start": "bun run build && node dist/deploy_commands.js && node dist/index.js",
-    "dev": "nodemon --exec ts-node src/index.ts",
-    "deploycommand": "bun run build && node dist/deploy_commands.js",
-    "cmd:deploy": "bun run build && node dist/command_deploy.js",
-    "cmd:reset": "bun run build && node dist/command_reset.js",
-    "lint": "bunx biome check .",
-    "lint:fix": "bunx biome check --write .",
-    "format": "bunx biome format --write .",
-    "test": "bun test src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
-    "test:coverage": "bun test --coverage src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
-    "test:watch": "bun test --watch src/__tests__/config src/__tests__/utils",
-    "test:integration": "bun test src/__tests__/integration",
-    "test:all": "bun test src/__tests__",
-    "docker:build": "docker build -t unthread-discord-bot .",
-    "docker:build:secure": "docker build --no-cache -t unthread-discord-bot .",
-    "docker:build:sbom": "docker build --sbom=true --provenance=mode=max -t unthread-discord-bot .",
-    "docker:run": "docker run --env-file .env unthread-discord-bot",
-    "sbom:generate": "./scripts/generate-sbom.sh"
-  },
-  "keywords": [],
-  "author": "Waren Gonzaga <opensource@warengonzaga.com> (https://warengonzaga.com)",
-  "contributors": [
-    "WG Tech Labs <opensource@wgtechlabs.com> (https://wgtechlabs.com)"
-  ],
-  "license": "AGPL-3.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/wgtechlabs/unthread-discord-bot.git"
-  },
-  "bugs": {
-    "url": "https://github.com/wgtechlabs/unthread-discord-bot/issues"
-  },
-  "engines": {
-    "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
-  },
-  "packageManager": "bun@1.3.13",
-  "dependencies": {
-    "@types/ioredis": "^5.0.0",
-    "@wgtechlabs/log-engine": "2.3.1",
-    "discord.js": "^14.26.4",
-    "dotenv": "^17.4.2",
-    "express": "^5.2.1",
-    "ioredis": "^5.10.1",
-    "pg": "^8.21.0",
-    "redis": "^6.0.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
-    "@types/bun": "^1.3.14",
-    "@types/express": "^5.0.6",
-    "@types/node": "^26.0.1",
-    "@types/pg": "^8.20.0",
-    "esbuild": "^0.28.0",
-    "nodemon": "^3.1.14",
-    "ts-node": "^10.9.2",
-    "typescript": "^6.0.3"
-  }
+	"name": "unthread-discord-bot",
+	"description": "Turn Discord community servers into real-time support ticket hubs — powered by Unthread.io",
+	"version": "1.1.5",
+	"private": true,
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "tsc",
+		"type-check": "tsc --noEmit",
+		"start": "bun run build && node dist/deploy_commands.js && node dist/index.js",
+		"dev": "nodemon --exec ts-node src/index.ts",
+		"deploycommand": "bun run build && node dist/deploy_commands.js",
+		"cmd:deploy": "bun run build && node dist/command_deploy.js",
+		"cmd:reset": "bun run build && node dist/command_reset.js",
+		"lint": "bunx biome check .",
+		"lint:fix": "bunx biome check --write .",
+		"format": "bunx biome format --write .",
+		"test": "bun test src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
+		"test:coverage": "bun test --coverage src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
+		"test:watch": "bun test --watch src/__tests__/config src/__tests__/utils",
+		"test:integration": "bun test src/__tests__/integration",
+		"test:all": "bun test src/__tests__",
+		"docker:build": "docker build -t unthread-discord-bot .",
+		"docker:build:secure": "docker build --no-cache -t unthread-discord-bot .",
+		"docker:build:sbom": "docker build --sbom=true --provenance=mode=max -t unthread-discord-bot .",
+		"docker:run": "docker run --env-file .env unthread-discord-bot",
+		"sbom:generate": "./scripts/generate-sbom.sh"
+	},
+	"keywords": [],
+	"author": "Waren Gonzaga <opensource@warengonzaga.com> (https://warengonzaga.com)",
+	"contributors": [
+		"WG Tech Labs <opensource@wgtechlabs.com> (https://wgtechlabs.com)"
+	],
+	"license": "AGPL-3.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/wgtechlabs/unthread-discord-bot.git"
+	},
+	"bugs": {
+		"url": "https://github.com/wgtechlabs/unthread-discord-bot/issues"
+	},
+	"engines": {
+		"node": "^22.0.0 || ^24.0.0 || ^26.0.0"
+	},
+	"packageManager": "bun@1.3.13",
+	"dependencies": {
+		"@types/ioredis": "^5.0.0",
+		"@wgtechlabs/log-engine": "2.3.1",
+		"discord.js": "^14.26.4",
+		"dotenv": "^17.4.2",
+		"express": "^5.2.1",
+		"ioredis": "^5.10.1",
+		"pg": "^8.21.0",
+		"redis": "^6.0.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.5.1",
+		"@types/bun": "^1.3.14",
+		"@types/express": "^5.0.6",
+		"@types/node": "^26.0.1",
+		"@types/pg": "^8.20.0",
+		"esbuild": "^0.28.0",
+		"nodemon": "^3.1.14",
+		"ts-node": "^10.9.2",
+		"typescript": "^6.0.3"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -44,15 +44,12 @@
   },
   "packageManager": "bun@1.3.13",
   "dependencies": {
-    "@keyv/redis": "^5.1.6",
     "@types/ioredis": "^5.0.0",
     "@wgtechlabs/log-engine": "2.3.1",
-    "cacheable": "^2.3.5",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ioredis": "^5.10.1",
-    "keyv": "^5.6.0",
     "pg": "^8.21.0",
     "redis": "^6.0.1"
   },

--- a/src/__tests__/infrastructure.test.ts
+++ b/src/__tests__/infrastructure.test.ts
@@ -58,15 +58,6 @@ describe('Test Infrastructure', () => {
 	});
 
 	describe('Storage Mocking', () => {
-		it('should mock Redis/Keyv correctly', async () => {
-			const Keyv = (await import('keyv')).default;
-			const cache = new Keyv();
-
-			expect(cache.get).toBeDefined();
-			expect(cache.set).toBeDefined();
-			expect(typeof (cache.get as unknown as { mock?: unknown }).mock).toBe('object');
-		});
-
 		it('should mock PostgreSQL correctly', async () => {
 			const { Pool } = await import('pg');
 			const pool = new Pool();

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -252,28 +252,6 @@ const mockFetchImplementation = vi.fn((url: string | Request, options?: RequestI
 // REDIS/DATABASE MOCKING
 // =============================================================================
 
-// Mock @keyv/redis
-mock.module('@keyv/redis', () => ({
-	default: vi.fn().mockImplementation(() => ({
-		get: vi.fn().mockResolvedValue(null),
-		set: vi.fn().mockResolvedValue(true),
-		delete: vi.fn().mockResolvedValue(true),
-		clear: vi.fn().mockResolvedValue(true),
-		has: vi.fn().mockResolvedValue(false),
-	})),
-}));
-
-// Mock keyv
-mock.module('keyv', () => ({
-	default: class MockKeyv {
-		get = vi.fn().mockResolvedValue(null);
-		set = vi.fn().mockResolvedValue(true);
-		delete = vi.fn().mockResolvedValue(true);
-		clear = vi.fn().mockResolvedValue(true);
-		has = vi.fn().mockResolvedValue(false);
-	},
-}));
-
 // Mock ioredis
 mock.module('ioredis', () => ({
 	default: vi.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- remove unused direct `keyv`, `@keyv/redis`, and `cacheable` dependencies
- regenerate `bun.lock` without Keyv/cacheable packages
- remove Keyv-only test mocks and the test that only exercised the Keyv mock

## Validation
- `bun install --frozen-lockfile` passed
- `bun run type-check` passed
- `bun test src/__tests__/infrastructure.test.ts` passed: 9 tests
- `bun run lint` was attempted and still reports unrelated pre-existing Biome findings outside this cleanup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wgtechlabs/codesmith/unthread-discord-bot/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->