### PR TITLE
🚀 release: ship build flow formatting fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,73 +1,73 @@
 {
-  "name": "unthread-discord-bot",
-  "description": "Turn Discord community servers into real-time support ticket hubs — powered by Unthread.io",
-  "version": "1.1.11",
-  "private": true,
-  "main": "dist/index.js",
-  "scripts": {
-    "build": "tsc",
-    "type-check": "tsc --noEmit",
-    "start": "bun run build && node dist/deploy_commands.js && node dist/index.js",
-    "dev": "bun --watch src/index.ts",
-    "deploycommand": "bun run build && node dist/deploy_commands.js",
-    "cmd:deploy": "bun run build && node dist/command_deploy.js",
-    "cmd:reset": "bun run build && node dist/command_reset.js",
-    "lint": "bunx biome check .",
-    "lint:fix": "bunx biome check --write .",
-    "format": "bunx biome format --write .",
-    "test": "bun test src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
-    "test:coverage": "bun test --coverage src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
-    "test:watch": "bun test --watch src/__tests__/config src/__tests__/utils",
-    "test:integration": "bun test src/__tests__/integration",
-    "test:all": "bun test src/__tests__",
-    "docker:build": "docker build -t unthread-discord-bot .",
-    "docker:build:secure": "docker build --no-cache -t unthread-discord-bot .",
-    "docker:build:sbom": "docker build --sbom=true --provenance=mode=max -t unthread-discord-bot .",
-    "docker:run": "docker run --env-file .env unthread-discord-bot",
-    "sbom:generate": "./scripts/generate-sbom.sh"
-  },
-  "keywords": [],
-  "author": "Waren Gonzaga <opensource@warengonzaga.com> (https://warengonzaga.com)",
-  "contributors": [
-    "WG Tech Labs <opensource@wgtechlabs.com> (https://wgtechlabs.com)"
-  ],
-  "license": "AGPL-3.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/wgtechlabs/unthread-discord-bot.git"
-  },
-  "bugs": {
-    "url": "https://github.com/wgtechlabs/unthread-discord-bot/issues"
-  },
-  "engines": {
-    "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
-  },
-  "packageManager": "bun@1.3.13",
-  "dependencies": {
-    "@types/ioredis": "^5.0.0",
-    "@wgtechlabs/log-engine": "2.3.1",
-    "discord.js": "^14.26.4",
-    "dotenv": "^17.4.2",
-    "express": "^5.2.1",
-    "ioredis": "^6.0.0",
-    "pg": "^8.21.0",
-    "redis": "^6.0.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
-    "@types/bun": "^1.3.14",
-    "@types/express": "^5.0.6",
-    "@types/node": "^26.0.1",
-    "@types/pg": "^8.20.0",
-    "esbuild": "^0.28.0",
-    "nodemon": "^3.1.14",
-    "ts-node": "^10.9.2",
-    "typescript": "^7.0.2"
-  },
-  "overrides": {
-    "brace-expansion": "^5.0.7",
-    "tar": "^7.5.19",
-    "undici": "^6.28.0",
-    "ws": "^8.21.0"
-  }
+	"name": "unthread-discord-bot",
+	"description": "Turn Discord community servers into real-time support ticket hubs — powered by Unthread.io",
+	"version": "1.1.11",
+	"private": true,
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "tsc",
+		"type-check": "tsc --noEmit",
+		"start": "bun run build && node dist/deploy_commands.js && node dist/index.js",
+		"dev": "bun --watch src/index.ts",
+		"deploycommand": "bun run build && node dist/deploy_commands.js",
+		"cmd:deploy": "bun run build && node dist/command_deploy.js",
+		"cmd:reset": "bun run build && node dist/command_reset.js",
+		"lint": "bunx biome check .",
+		"lint:fix": "bunx biome check --write .",
+		"format": "bunx biome format --write .",
+		"test": "bun test src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
+		"test:coverage": "bun test --coverage src/__tests__/config src/__tests__/utils src/__tests__/infrastructure.test.ts",
+		"test:watch": "bun test --watch src/__tests__/config src/__tests__/utils",
+		"test:integration": "bun test src/__tests__/integration",
+		"test:all": "bun test src/__tests__",
+		"docker:build": "docker build -t unthread-discord-bot .",
+		"docker:build:secure": "docker build --no-cache -t unthread-discord-bot .",
+		"docker:build:sbom": "docker build --sbom=true --provenance=mode=max -t unthread-discord-bot .",
+		"docker:run": "docker run --env-file .env unthread-discord-bot",
+		"sbom:generate": "./scripts/generate-sbom.sh"
+	},
+	"keywords": [],
+	"author": "Waren Gonzaga <opensource@warengonzaga.com> (https://warengonzaga.com)",
+	"contributors": [
+		"WG Tech Labs <opensource@wgtechlabs.com> (https://wgtechlabs.com)"
+	],
+	"license": "AGPL-3.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/wgtechlabs/unthread-discord-bot.git"
+	},
+	"bugs": {
+		"url": "https://github.com/wgtechlabs/unthread-discord-bot/issues"
+	},
+	"engines": {
+		"node": "^22.0.0 || ^24.0.0 || ^26.0.0"
+	},
+	"packageManager": "bun@1.3.13",
+	"dependencies": {
+		"@types/ioredis": "^5.0.0",
+		"@wgtechlabs/log-engine": "2.3.1",
+		"discord.js": "^14.26.4",
+		"dotenv": "^17.4.2",
+		"express": "^5.2.1",
+		"ioredis": "^6.0.0",
+		"pg": "^8.21.0",
+		"redis": "^6.0.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.5.1",
+		"@types/bun": "^1.3.14",
+		"@types/express": "^5.0.6",
+		"@types/node": "^26.0.1",
+		"@types/pg": "^8.20.0",
+		"esbuild": "^0.28.0",
+		"nodemon": "^3.1.14",
+		"ts-node": "^10.9.2",
+		"typescript": "^7.0.2"
+	},
+	"overrides": {
+		"brace-expansion": "^5.0.7",
+		"tar": "^7.5.19",
+		"undici": "^6.28.0",
+		"ws": "^8.21.0"
+	}
 }


### PR DESCRIPTION
Restores Biome formatting for package.json so the unified Build Flow lint job passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wgtechlabs/codesmith/unthread-discord-bot/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->